### PR TITLE
Allow to change failback/failover/recovery settings

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'puppet-pgpool2'
-version '0.2.0'
+version '0.2.1'
 source 'git://github.com/jrodriguezjr/puppet-pgpool2.git'
 author 'jrodriguezjr'
 license 'Apache License, Version 2.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,17 @@ class pgpool2 (
   $health_check_max_retries       = $pgpool2::params::health_check_max_retries,
   $health_check_retry_delay       = $pgpool2::params::health_check_retry_delay,
 
+  $failover_command               = $pgpool2::params::failover_command,
+  $failback_command               = $pgpool2::params::failback_command,
+  $fail_over_on_backend_error     = $pgpool2::params::fail_over_on_backend_error,
+
+  $recovery_user                  = $pgpool2::params::recovery_user,
+  $recovery_password              = $pgpool2::params::recovery_password,
+  $recovery_1st_stage_command     = $pgpool2::params::recovery_1st_stage_command,
+  $recovery_2nd_stage_command     = $pgpool2::params::recovery_2nd_stage_command,
+  $recovery_timeout               = $pgpool2::params::recovery_timeout,
+  $client_idle_limit_in_recovery  = $pgpool2::params::client_idle_limit_in_recovery,
+
   $confdir                        = $pgpool2::params::confdir,
   $pgpool_conf_path               = $pgpool2::params::pgpool_conf_path,
   $pool_hba_conf_path             = $pgpool2::params::pool_hba_conf_path,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -94,6 +94,19 @@ class pgpool2::params {
   $health_check_password      = ' '
   $health_check_max_retries   = 0
   $health_check_retry_delay   = 1
+
+  # - FAILOVER AND FAILBACK -
+  $failover_command           = ''
+  $failback_command           = ''
+  $fail_over_on_backend_error = 'off'
+
+  # - ONLINE RECOVERY -
+  $recovery_user                 = 'nobody'
+  $recovery_password             = ''
+  $recovery_1st_stage_command    = ''
+  $recovery_2nd_stage_command    = ''
+  $recovery_timeout              = 90
+  $client_idle_limit_in_recovery = 0
   # PGPOOL Config Parameters - end
 
   # pgpool-II replication manager - PCP Configuration

--- a/templates/pgpool.conf.erb
+++ b/templates/pgpool.conf.erb
@@ -366,63 +366,62 @@ health_check_retry_delay = <%= @health_check_retry_delay %>
 # FAILOVER AND FAILBACK
 #------------------------------------------------------------------------------
 
-failover_command = ''
-                                   # Executes this command at failover
-                                   # Special values:
-                                   #   %d = node id
-                                   #   %h = host name
-                                   #   %p = port number
-                                   #   %D = database cluster path
-                                   #   %m = new master node id
-                                   #   %H = hostname of the new master node
-                                   #   %M = old master node id
-                                   #   %P = old primary node id
-                                   #   %% = '%' character
-failback_command = ''
-                                   # Executes this command at failback.
-                                   # Special values:
-                                   #   %d = node id
-                                   #   %h = host name
-                                   #   %p = port number
-                                   #   %D = database cluster path
-                                   #   %m = new master node id
-                                   #   %H = hostname of the new master node
-                                   #   %M = old master node id
-                                   #   %P = old primary node id
-                                   #   %% = '%' character
+failover_command = '<%= @failover_command %>'
+                                    # Executes this command at failover
+                                    # Special values:
+                                    #   %d = node id
+                                    #   %h = host name
+                                    #   %p = port number
+                                    #   %D = database cluster path
+                                    #   %m = new master node id
+                                    #   %H = hostname of the new master node
+                                    #   %M = old master node id
+                                    #   %P = old primary node id
+                                    #   %% = '%' character
+failback_command = '<%= @failback_command %>'
+                                    # Executes this command at failback.
+                                    # Special values:
+                                    #   %d = node id
+                                    #   %h = host name
+                                    #   %p = port number
+                                    #   %D = database cluster path
+                                    #   %m = new master node id
+                                    #   %H = hostname of the new master node
+                                    #   %M = old master node id
+                                    #   %P = old primary node id
+                                    #   %% = '%' character
 
-fail_over_on_backend_error = off
-                                   # Initiates failover when writing to the
-                                   # backend communication socket fails
-                                   # This is the same behaviour of pgpool-II
-                                   # 2.2.x and previous releases
-                                   # If set to off, pgpool will report an
-                                   # error and disconnect the session.
+fail_over_on_backend_error = <%= @fail_over_on_backend_error %>
+                                    # Initiates failover when writing to the
+                                    # backend communication socket fails
+                                    # This is the same behaviour of pgpool-II
+                                    # 2.2.x and previous releases
+                                    # If set to off, pgpool will report an
+                                    # error and disconnect the session.
 
 
 #------------------------------------------------------------------------------
 # ONLINE RECOVERY
 #------------------------------------------------------------------------------
 
-recovery_user = 'nobody'
-                                   # Online recovery user
-recovery_password = ''
-                                   # Online recovery password
-recovery_1st_stage_command = ''
-                                   # Executes a command in first stage
-recovery_2nd_stage_command = ''
-                                   # Executes a command in second stage
-recovery_timeout = 90
-                                   # Timeout in seconds to wait for the
-                                   # recovering node's postmaster to start up
-                                   # 0 means no wait
-client_idle_limit_in_recovery = 0
-                                   # Client is disconnected after being idle
-                                   # for that many seconds in the second stage
-                                   # of online recovery
-                                   # 0 means no disconnection
-                                   # -1 means immediate disconnection
-
+recovery_user = '<%= @recovery_user %>'
+                                    # Online recovery user
+recovery_password = '<%= @recovery_password %>'
+                                    # Online recovery password
+recovery_1st_stage_command = '<%= @recovery_1st_stage_command %>'
+                                    # Executes a command in first stage
+recovery_2nd_stage_command = '<%= @recovery_2nd_stage_command %>'
+                                    # Executes a command in second stage
+recovery_timeout = <%= @recovery_timeout %>
+                                    # Timeout in seconds to wait for the
+                                    # recovering node's postmaster to start up
+                                    # 0 means no wait
+client_idle_limit_in_recovery = <%= @client_idle_limit_in_recovery %>
+                                    # Client is disconnected after being idle
+                                    # for that many seconds in the second stage
+                                    # of online recovery
+                                    # 0 means no disconnection
+                                    # -1 means immediate disconnection
 
 #------------------------------------------------------------------------------
 # OTHERS


### PR DESCRIPTION
To setup the correct failover, the module misses control
on some parameters in the pgpool.conf. Thus, this commit
enables them in the module.